### PR TITLE
Add support for Android with Termux - fixes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 'use strict';
 const path = require('path');
 const execa = require('execa');
+const termux = require('./lib/termux.js');
 
 const handler = err => {
 	if (err.code === 'ENOENT') {
-		throw new Error('Couldn\'t find the required `xsel` binary. On Debian/Ubuntu you can install it with: sudo apt install xsel');
+		let message = 'Couldn\'t find the required `xsel` binary. On Debian/Ubuntu you can install it with: sudo apt install xsel';
+		if (err.path === 'termux-clipboard-get' || err.path === 'termux-clipboard-set') {
+			message = 'Couldn\'t find the termux-api scripts. You can install them with: apt install termux-api';
+		}
+		throw new Error(message);
 	}
 
 	throw err;
@@ -69,6 +74,11 @@ function platform() {
 			return darwin;
 		case 'win32':
 			return win32;
+		case 'android':
+			if (process.env.PREFIX !== '/data/data/com.termux/files/usr') {
+				throw new Error('You need to install Termux for this module to work on Android: https://termux.com');
+			}
+			return termux(handler);
 		default:
 			return linux;
 	}

--- a/lib/termux.js
+++ b/lib/termux.js
@@ -1,0 +1,23 @@
+'use strict';
+const execa = require('execa');
+
+module.exports = handler => {
+	return {
+		copy: opts => execa('termux-clipboard-set', [], opts).catch(handler),
+		paste: opts => execa.stdout('termux-clipboard-get', [], opts).catch(handler),
+		copySync: opts => {
+			try {
+				return execa.sync('termux-clipboard-set', [], opts);
+			} catch (err) {
+				handler(err);
+			}
+		},
+		pasteSync: opts => {
+			try {
+				return execa.sync('termux-clipboard-get', [], opts);
+			} catch (err) {
+				handler(err);
+			}
+		}
+	};
+};


### PR DESCRIPTION
Hello,
This PR adds support for the [Termux](https://termux.com/) environment on Android (as discussed in #9).
It throws an error if the user uses Android without Termux as there is no way to access the clipboard on a standard Android install.
Every test passes on my Android phone.