### PR TITLE
[Demo] Add powershell paste after unicode test to show it is not right in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ test_script:
   - node --version
   - npm --version
   - npm test
-  - ps: GetClipboard
+  - ps: Get-Clipboard

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,4 @@ test_script:
   - node --version
   - npm --version
   - npm test
+  - ps: GetClipboard

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,6 @@ test_script:
   - npm --version
   - npm test
   - ps: Get-Clipboard
+  - npm test
+deploy_script:
+  -ps: Get-Clipboard

--- a/test.js
+++ b/test.js
@@ -22,7 +22,7 @@ test('works with ascii', async t => {
 	t.is(await writeRead(f), f);
 });
 
-test('works with unicode', async t => {
+test.only('works with unicode', async t => {
 	const f = 'ĀāĂăĄąĆćĈĉĊċČčĎ ፰፱፲፳፴፵፶፷፸፹፺፻፼ æøå ±';
 	t.is(await writeRead(f), f);
 });


### PR DESCRIPTION
This is not to be merged, I wanted to get appveyor to run to show a print out of the unicode test failing on windows.

The last line of the console for the appveyor build should be ``` ĀāĂăĄąĆćĈĉĊċČčĎ ፰፱፲፳፴፵፶፷፸፹፺፻፼ æøå ±```