### PR TITLE
Better Windows arch detection for x64

### DIFF
--- a/lib/windows.js
+++ b/lib/windows.js
@@ -1,9 +1,10 @@
 'use strct';
 const path = require('path');
 const execa = require('execa');
+const arch = require('arch');
 
 // Binaries from: https://github.com/sindresorhus/win-clipboard
-const winBinPath = process.arch === 'x64' ?
+const winBinPath = arch() === 'x64' ?
 	path.join(__dirname, '../fallbacks/windows/clipboard_x86_64.exe') :
 	path.join(__dirname, '../fallbacks/windows/clipboard_i686.exe');
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"xsel"
 	],
 	"dependencies": {
+		"arch": "^2.1.0",
 		"execa": "^0.8.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
A tiny update/improvement to #32 to better detect x64 (using a new dependency). See quick discussion at end of #30 