### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.DS_Store


### PR DESCRIPTION
It looks like a few `.DS_Store` files were published to npm.

See the following:

- https://unpkg.com/clipboardy@1.2.3/fallbacks/
- https://unpkg.com/clipboardy@1.2.3/fallbacks/windows/

This will prevent that from happening because npm will respect the .gitignore file if no [.npmignore](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package) file is present.