### PR TITLE
Improve error reporting on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -46,8 +46,12 @@ const xselWithFallbackSync = (argumentList, options) => {
 };
 
 module.exports = {
-	copy: async options => { await xselWithFallback(copyArguments, options); },
+	copy: async options => {
+		await xselWithFallback(copyArguments, options);
+	},
+	copySync: options => {
+		xselWithFallbackSync(copyArguments, options);
+	},
 	paste: options => xselWithFallback(pasteArguments, options),
-	copySync: options => { xselWithFallbackSync(copyArguments, options); },
 	pasteSync: options => xselWithFallbackSync(pasteArguments, options)
 };

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -2,59 +2,52 @@
 const path = require('path');
 const execa = require('execa');
 
-const handler = error => {
-	if (error.code === 'ENOENT') {
-		throw new Error('Couldn\'t find the required `xsel` binary. On Debian/Ubuntu you can install it with: sudo apt install xsel');
+const xsel = 'xsel';
+const xselFallback = path.join(__dirname, '../fallbacks/linux/xsel');
+
+const copyArguments = ['--clipboard', '--input'];
+const pasteArguments = ['--clipboard', '--output'];
+
+const makeError = (xselError, fallbackError) => {
+	let error;
+	if (xselError.code === 'ENOENT') {
+		error = new Error('Couldn\'t find the `xsel` binary and fallback didn\'t work. On Debian/Ubuntu you can install xsel with: sudo apt install xsel');
+	} else {
+		error = new Error('Both xsel and fallback failed');
+		error.xselError = xselError;
 	}
 
-	throw error;
+	error.fallbackError = fallbackError;
+	return error;
 };
 
-const xsel = path.join(__dirname, '../fallbacks/linux/xsel');
-
-module.exports = {
-	copy: async options => {
+const xselWithFallback = async (argumentList, options) => {
+	try {
+		return await execa.stdout(xsel, argumentList, options);
+	} catch (xselError) {
 		try {
-			await execa(xsel, ['--clipboard', '--input'], options);
-		} catch (_) {
-			try {
-				await execa('xsel', ['--clipboard', '--input'], options);
-			} catch (error) {
-				handler(error);
-			}
-		}
-	},
-	paste: async options => {
-		try {
-			return await execa.stdout(xsel, ['--clipboard', '--output'], options);
-		} catch (_) {
-			try {
-				return await execa.stdout('xsel', ['--clipboard', '--output'], options);
-			} catch (error) {
-				handler(error);
-			}
-		}
-	},
-	copySync: options => {
-		try {
-			execa.sync(xsel, ['--clipboard', '--input'], options);
-		} catch (_) {
-			try {
-				execa.sync('xsel', ['--clipboard', '--input'], options);
-			} catch (error) {
-				handler(error);
-			}
-		}
-	},
-	pasteSync: options => {
-		try {
-			return execa.sync(xsel, ['--clipboard', '--output'], options);
-		} catch (_) {
-			try {
-				return execa.sync('xsel', ['--clipboard', '--output'], options);
-			} catch (error) {
-				handler(error);
-			}
+			return await execa.stdout(xselFallback, argumentList, options);
+		} catch (fallbackError) {
+			throw makeError(xselError, fallbackError);
 		}
 	}
+};
+
+const xselWithFallbackSync = (argumentList, options) => {
+	try {
+		return execa.sync(xsel, argumentList, options);
+	} catch (xselError) {
+		try {
+			return execa.sync(xselFallback, argumentList, options);
+		} catch (fallbackError) {
+			throw makeError(xselError, fallbackError);
+		}
+	}
+};
+
+module.exports = {
+	copy: async options => { await xselWithFallback(copyArguments, options); },
+	paste: options => xselWithFallback(pasteArguments, options),
+	copySync: options => { xselWithFallbackSync(copyArguments, options); },
+	pasteSync: options => xselWithFallbackSync(pasteArguments, options)
 };


### PR DESCRIPTION
Fixes #48, plus some more.

Made fallback to actually be executed only if system `xsel` failed. (There is much more chances fallback breaks the system compared to `xsel` installed in it.)

Doesn't eat fallback errors anymore, instead creates errors which show both fallback and system `xsel` source errors.

Once https://github.com/sindresorhus/execa/pull/212 get released, this will output proper descriptive errors about what happened.

