### PR TITLE
Support Windows Subsystem for Linux (WSL)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const termux = require('./lib/termux.js');
 const linux = require('./lib/linux.js');
 const macos = require('./lib/macos.js');
@@ -17,7 +18,8 @@ const platformLib = (() => {
 
 			return termux;
 		default:
-			return linux;
+			const isWSL = /(Microsoft|WSL)/.test(fs.readFileSync('/proc/version'));
+			return isWSL ? windows : linux;
 	}
 })();
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const fs = require('fs');
+const isWsl = require('is-wsl');
 const termux = require('./lib/termux.js');
 const linux = require('./lib/linux.js');
 const macos = require('./lib/macos.js');
@@ -18,8 +18,7 @@ const platformLib = (() => {
 
 			return termux;
 		default:
-			const isWSL = /(Microsoft|WSL)/.test(fs.readFileSync('/proc/version'));
-			return isWSL ? windows : linux;
+			return isWsl ? windows : linux;
 	}
 })();
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 	],
 	"dependencies": {
 		"arch": "^2.1.1",
-		"execa": "^1.0.0"
+		"execa": "^1.0.0",
+		"is-wsl": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",


### PR DESCRIPTION
WSL is a proper Linux distro so `process.platform === 'linux'`. However, most people won't have an X server installed so `xsel` won't work.
But WSL can call native windows executables and the fallback/clipboard_*.exe programs work fine.
Thus, if we use the windows lib on WSL, everything just works.
Code for checking whether we're running in WSL is based on https://stackoverflow.com/a/43618657, which has a quote from a WSL dev as the source.