### PR TITLE
Add support for WSL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 'use strict';
-
+const isWSL = require('is-wsl');
 const termux = require('./lib/termux.js');
 const linux = require('./lib/linux.js');
 const macos = require('./lib/macos.js');
 const windows = require('./lib/windows.js');
-const isWSL = require('is-wsl');
 
 const platformLib = (() => {
 	switch (process.platform) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 'use strict';
+
 const termux = require('./lib/termux.js');
 const linux = require('./lib/linux.js');
 const macos = require('./lib/macos.js');
 const windows = require('./lib/windows.js');
+const isWSL = require('is-wsl');
 
 const platformLib = (() => {
 	switch (process.platform) {
@@ -17,6 +19,10 @@ const platformLib = (() => {
 
 			return termux;
 		default:
+			if (isWSL) {
+				return windows;
+			}
+
 			return linux;
 	}
 })();

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const platformLib = (() => {
 
 			return termux;
 		default:
-			// Process.platform is "linux" for WSL
+			// `process.platform === 'linux'` for WSL.
 			if (isWSL) {
 				return windows;
 			}

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const platformLib = (() => {
 
 			return termux;
 		default:
+			// Process.platform is "linux" for WSL
 			if (isWSL) {
 				return windows;
 			}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 	],
 	"dependencies": {
 		"arch": "^2.1.1",
-		"execa": "^1.0.0"
+		"execa": "^1.0.0",
+		"is-wsl": "^2.1.1"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
-
 import {EOL} from 'os';
-import clipboardy from '.';
 import {serial as test} from 'ava';
+import clipboardy from '.';
 
 const writeRead = async input => {
 	await clipboardy.write(input);

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
+
 import {EOL} from 'os';
-import {serial as test} from 'ava';
 import clipboardy from '.';
+import {serial as test} from 'ava';
 
 const writeRead = async input => {
 	await clipboardy.write(input);


### PR DESCRIPTION
Fixes #53

I've tested this locally on my machine; I'm happy to take ownership of this feature, and so be assigned any issues that might arise from it :)

Here's a quick screenshot of it being run from within the Linux subsystem (i.e not on the native Windows filesystem):

![image](https://user-images.githubusercontent.com/3151613/74098796-01209b80-4b81-11ea-8f5a-ed8b885bcba7.png)

```
const c = require('clipboardy');

console.log(c.readSync());
c.writeSync('hello world!');
```

I don't have any development sdks (aside from say the custom JDK that is packed with IntelliJ) installed on my host; I operate purely in WSL for my command line stuff, so the exes run fine regardless of location.