### PR TITLE
feat: allow configuring custom fallbacks root

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,24 @@ declare const clipboard: {
 	```
 	*/
 	readSync(): string;
+
+	/**
+	Configure the root directory for fallback binaries.
+	This is useful for bundlers or packagers (e.g. Node.js SEA) who need
+	to control where `clipboardy` looks for fallback binaries like `xsel` or
+	Windows executables.
+
+	@example
+	```
+	import clipboard from 'clipboardy';
+
+	// Tell clipboardy to load fallbacks from a custom directory
+	clipboard.configure({fallbacksRoot: '/path/to/fallbacks'});
+	```
+
+	@param options.fallbacksRoot The directory path where fallback binaries are located.
+	*/
+	configure(options: {fallbacksRoot: string}): void;
 };
 
 export default clipboard;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import termux from './lib/termux.js';
 import linux from './lib/linux.js';
 import macos from './lib/macos.js';
 import windows from './lib/windows.js';
+import {setFallbacksRoot} from './lib/fallbacks.js';
 
 const platformLib = (() => {
 	switch (process.platform) {
@@ -55,5 +56,7 @@ clipboard.writeSync = text => {
 };
 
 clipboard.readSync = () => platformLib.pasteSync({stripFinalNewline: false});
+
+clipboard.configure = ({fallbacksRoot}) => setFallbacksRoot(fallbacksRoot);
 
 export default clipboard;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,3 +5,4 @@ clipboard.writeSync('🦄');
 expectType<Promise<void>>(clipboard.write('🦄'));
 expectType<string>(clipboard.readSync());
 expectType<Promise<string>>(clipboard.read());
+expectType<void>(clipboard.configure({fallbacksRoot: '/tmp/fallbacks'}));

--- a/lib/fallbacks.js
+++ b/lib/fallbacks.js
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let currentFallbacksRoot = path.join(__dirname, '../fallbacks');
+
+export function getFallbacksRoot() {
+	return currentFallbacksRoot;
+}
+
+export function setFallbacksRoot(newRoot) {
+	if (typeof newRoot !== 'string') {
+		throw new TypeError('Fallbacks root must be a string');
+	}
+
+	if (!path.isAbsolute(newRoot)) {
+		throw new Error('Fallbacks root must be an absolute path');
+	}
+
+	currentFallbacksRoot = newRoot;
+}

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,11 +1,9 @@
 import path from 'node:path';
-import {fileURLToPath} from 'node:url';
 import {execa, execaSync} from 'execa';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import {getFallbacksRoot} from './fallbacks.js';
 
 const xsel = 'xsel';
-const xselFallback = path.join(__dirname, '../fallbacks/linux/xsel');
+const xselFallback = path.join(getFallbacksRoot(), 'linux/xsel');
 
 const copyArguments = ['--clipboard', '--input'];
 const pasteArguments = ['--clipboard', '--output'];

--- a/lib/windows.js
+++ b/lib/windows.js
@@ -1,14 +1,12 @@
 import path from 'node:path';
-import {fileURLToPath} from 'node:url';
 import {execa, execaSync} from 'execa';
 import {is64bitSync} from 'is64bit';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import {getFallbacksRoot} from './fallbacks.js';
 
 const binarySuffix = is64bitSync() ? 'x86_64' : 'i686';
 
 // Binaries from: https://github.com/sindresorhus/win-clipboard
-const windowBinaryPath = path.join(__dirname, `../fallbacks/windows/clipboard_${binarySuffix}.exe`);
+const windowBinaryPath = path.join(getFallbacksRoot(), `windows/clipboard_${binarySuffix}.exe`);
 
 const clipboard = {
 	copy: async options => execa(windowBinaryPath, ['--copy'], options),

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,16 @@ Read (paste) from the clipboard synchronously.
 
 **Doesn't work in browsers.**
 
+#### .configure(options)
+
+Configure the root directory for fallback binaries.
+
+This is useful for bundlers or packagers (e.g. Node.js SEA) who need to control where `clipboardy` looks for fallback binaries like `xsel` or Windows executables.
+
+##### options
+
+- `fallbacksRoot` (string) The directory path where fallback binaries are located.
+
 ## FAQ
 
 #### Where can I find the source of the bundled binaries?


### PR DESCRIPTION
The PR adds a new `configure({ fallbacksRoot })` API and a corresponding `getFallbacksRoot()` getter, so that consumers can override the default `fallbacks/` directory used to locate binaries like `xsel` or `clipboard_*.exe`.

This is useful for packaging scenarios (e.g. Node.js SEA or other single-executable workflows) where the fallbacks must live outside the default `node_modules/clipboardy/fallbacks` path and often need to be extracted or copied to a custom location at runtime.

Closes: sindresorhus/clipboardy#101

----
Readme preview: https://github.com/dankeboy36/clipboardy/tree/origin/feat/101/can-configure-fallback-root?tab=readme-ov-file#configureoptions