### PR TITLE
fix: make it compatible with termux-chroot

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const platformLib = (() => {
 		}
 
 		case 'android': {
-			if (process.env.PREFIX !== '/data/data/com.termux/files/usr') {
+			if (process.env.TERMUX__PREFIX === undefined) {
 				throw new Error('You need to install Termux for this module to work on Android: https://termux.com');
 			}
 


### PR DESCRIPTION
The Termux prefix may change depending on how the user has configured it.The Termux prefix can change depending on how the user has configured it. It is safer to use ˋTERMUX__PREFIX === undefinedˋ