### PR TITLE
Fix Termux detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const platformLib = (() => {
 		}
 
 		case 'android': {
-			if (process.env.TERMUX__PREFIX === undefined) {
+			if (process.env.TERMUX_VERSION === undefined) {
 				throw new Error('You need to install Termux for this module to work on Android: https://termux.com');
 			}
 


### PR DESCRIPTION
Basically, #104 broke Termux detection for some versions, so I'm fixing the fix.
Fixes #106

TERMUX__PREFIX is not set in Termux versions <0.118.2 and from Google Play Store. This commit fixes it by checking for the TERMUX_VERSION variable instead (this one is present in all Termux versions).